### PR TITLE
Change gnuplot script generator.

### DIFF
--- a/src/ForSyDe/Shallow/CTLib.hs
+++ b/src/ForSyDe/Shallow/CTLib.hs
@@ -677,13 +677,14 @@ plotCT' step sigs = plotSig (expandSig 1 sigs)
                              | otherwise      = c   : (replChar replSet s)
       dumpSig :: (Num a, Show a) => [(Rational,a)] -> String
       dumpSig points = concatMap f points
-        where f (x,y) = show ((fromRational x) :: Float) ++ "    " 
+        where f (x,y) = show ((fromRational x) :: Float) ++ ";" 
                         ++ show (y) ++ "\n"
 
       mkPlotScript :: [(String  -- the file name of the dat file
                        ,String  -- the label for the signal to be drawn
                        )] -> String  -- the gnuplot script
-      mkPlotScript ns = "set xlabel \"seconds\" \n"
+      mkPlotScript ns = "set datafile separator \";\" \n"
+                        ++ "set xlabel \"seconds\" \n"
                         ++ "plot " ++ (f1 ns) ++ "\n"
                         ++ "set terminal postscript eps color\n"
                         ++ "set output \"" ++ plotFileName++".eps\"\n"


### PR DESCRIPTION
Changed CTLib plotCT' function. I don't know if it is a specific OSX specific issue with gnuplot, but it only works correctly if there is an explicit data separator (as ";" or ",").

Now I can get this type of graphic instead of a line.
[ct-moc-graph-ctOutput.pdf.pdf](https://github.com/forsyde/forsyde-shallow/files/629846/ct-moc-graph-ctOutput.pdf.pdf)
