### PR TITLE
Fixed compile error with GHC 8.10.3's new System.Random

### DIFF
--- a/forsyde-shallow.cabal
+++ b/forsyde-shallow.cabal
@@ -1,11 +1,11 @@
 name:           forsyde-shallow
-version:        3.4.0.0
+version:        3.4.0.1
 cabal-version:  >= 1.8
 build-type:     Simple
 license:        BSD3
 license-file:   LICENSE
 author:         ForSyDe Group, KTH/EECS/ELE
-copyright:      Copyright (c) 2003-2018 ForSyDe Group, KTH/EECS/ELE
+copyright:      Copyright (c) 2003-2021 ForSyDe Group, KTH/EECS/ELE
 maintainer:     ForSyDe Group <forsyde-dev@eecs.kth.se>
 homepage:       http://forsyde.ict.kth.se/
 stability:      alpha
@@ -22,6 +22,7 @@ tested-with:    GHC==7.10.3
               , GHC==8.0.2
               , GHC==8.2.1
               , GHC==8.4.4
+              , GHC==8.10.3
 
 -- In order to include all this files with sdist
 extra-source-files: LICENSE,

--- a/src/ForSyDe/Shallow/Utility/Gaussian.hs
+++ b/src/ForSyDe/Shallow/Utility/Gaussian.hs
@@ -19,7 +19,7 @@ where
 import ForSyDe.Shallow.MoC.Untimed
 import ForSyDe.Shallow.Core.Signal
 
-import System.Random
+import qualified System.Random
 
 -- |To generate an infinite Signal of Gaussian values
 pGaussianNoise:: Double -- Mean value of the Gaussian noise
@@ -33,15 +33,15 @@ pGaussianNoise mean variance = mapU 2 gaussianXY . pUnitNormXY
     gaussianXY _  = error "gaussianXY: unexpected pattern."
 
 -- |To get a uniform random variable in the range [0, 1]
-uniform :: (Fractional a, RandomGen g, Random a) => 
+uniform :: (Fractional a, System.Random.RandomGen g, System.Random.Random a) => 
   g -> (a, g)
-uniform rGen = randomR (0.0,1.0) rGen
+uniform rGen = System.Random.randomR (0.0,1.0) rGen
 
 -- |To generate an infinite signal of unit normal random variables,
 -- with the specified seed
 pUnitNormXY :: Int     -- The seed
      -> Signal Double  -- The infinite ouput signal
-pUnitNormXY = mapU 3 unitNormXY . signal . svGenerator . mkStdGen
+pUnitNormXY = mapU 3 unitNormXY . signal . svGenerator . System.Random.mkStdGen
   where
     unitNormXY [s, v1, v2] = [sqrt(-2 * log(s) / s) * v1,
           sqrt(-2 * log(s) / s) * v2]
@@ -49,7 +49,7 @@ pUnitNormXY = mapU 3 unitNormXY . signal . svGenerator . mkStdGen
 
 
 -- |To generate the s, v1, v2 value
-svGenerator :: StdGen -> [Double]
+svGenerator :: System.Random.StdGen -> [Double]
 svGenerator s
     | sVal >=1 = []++ svGenerator newStdG
     | otherwise = svVal ++ svGenerator newStdG
@@ -58,7 +58,7 @@ svGenerator s
     svVal = fst svGen1
     sVal = head svVal
     newStdG = snd svGen1
-    svHelper :: StdGen -> ([Double], StdGen)
+    svHelper :: System.Random.StdGen -> ([Double], System.Random.StdGen)
     svHelper stdG = ([s, v1, v2], sNew2)
       where
         (u1, sNew1) = uniform stdG


### PR DESCRIPTION
Fixes an ambiguity error introduced with the latest `GHC` (> 8.10.3) which provided a function names `uniform`, clashing with the ones provided by the library.